### PR TITLE
Feature/income

### DIFF
--- a/src/JSONFormData/FirstTimeApplication.js
+++ b/src/JSONFormData/FirstTimeApplication.js
@@ -3,7 +3,7 @@ import TextBoxWithAccordian from '../components/Forms/TextboxWithAccordian';
 // import TextFieldWithCheckbox from '../components/Forms/TextFieldWithCheckbox';
 import RadioWithRadio from '../components/Forms/RadioWithRadio';
 import RadioWithTextField from '../components/Forms/RadioWithTextField';
-// import RadioWithSelect from '../components/Forms/RadioWithSelect';
+import RadioWithSelect from '../components/Forms/RadioWithSelect';
 
 
 var firstTimeApplication = [
@@ -239,41 +239,41 @@ var firstTimeApplication = [
       }
     }
   },
-  // {
-  //   'label': {
-  //     'en': {
-  //       'text': 'What was your total income for the 2016/2017 tax year?'
-  //     },
-  //     'mi': {
-  //       'text': 'What was your total income for the 2016/2017 tax year?'
-  //     }
-  //   },
-  //   'instructions': {
-  //     'en': {
-  //       'text': 'This is the money received, before tax, for the year 1 April 2016 to 31 March 2017. Enter any income you or your partner/joint home owner(s) received for the tax year. Use gross amounts unless otherwise indicated. Select any that you receive'
-  //     },
-  //     'mi': {
-  //       'text': 'This is the money received, before tax, for the year 1 April 2016 to 31 March 2017. Enter any income you or your partner/joint home owner(s) received for the tax year. Use gross amounts unless otherwise indicated. Select any that you receive'
-  //     }
-  //   },
-  //   'accordianLabel': {
-  //     'en': {
-  //       'text': 'What is a gross amount?'
-  //     },
-  //     'mi': {
-  //       'text': 'What is a gross amount?'
-  //     }
-  //   },
-  //   'accordianText': {
-  //     'en': {
-  //       'text': 'Satisfactory proof of income includes: <ul><li>income confirmation from Work and Income</li><li>income confirmation from Inland Revenue</li><li>investment earning statements for the tax year </li><li>statement of earnings from your employer.</li>Additionally for self-employed people:</li><li>a copy of your complete set of financial accounts, IR3B or IR10 you provided to Inland Revenue for the income year 1 April 2016 to 31 March 2017</li><li>you cannot offset business losses against other income</li><li>business losses should be entered as $0.</li></ul>'
-  //     },
-  //     'mi': {
-  //       'text': 'Satisfactory proof of income includes: <ul><li>income confirmation from Work and Income</li><li>income confirmation from Inland Revenue</li><li>investment earning statements for the tax year </li><li>statement of earnings from your employer.</li>Additionally for self-employed people:</li><li>a copy of your complete set of financial accounts, IR3B or IR10 you provided to Inland Revenue for the income year 1 April 2016 to 31 March 2017</li><li>you cannot offset business losses against other income</li><li>business losses should be entered as $0.</li></ul>'
-  //     }
-  //   },
-  //   'component': RadioWithSelect
-  // },
+  {
+    'label': {
+      'en': {
+        'text': 'What was your total income for the 2016/2017 tax year?'
+      },
+      'mi': {
+        'text': 'What was your total income for the 2016/2017 tax year?'
+      }
+    },
+    'instructions': {
+      'en': {
+        'text': 'This is the money received, before tax, for the year 1 April 2016 to 31 March 2017. Enter any income you or your partner/joint home owner(s) received for the tax year. Use gross amounts unless otherwise indicated. Select any that you receive'
+      },
+      'mi': {
+        'text': 'This is the money received, before tax, for the year 1 April 2016 to 31 March 2017. Enter any income you or your partner/joint home owner(s) received for the tax year. Use gross amounts unless otherwise indicated. Select any that you receive'
+      }
+    },
+    'accordianLabel': {
+      'en': {
+        'text': 'What is a gross amount?'
+      },
+      'mi': {
+        'text': 'What is a gross amount?'
+      }
+    },
+    'accordianText': {
+      'en': {
+        'text': 'Satisfactory proof of income includes: <ul><li>income confirmation from Work and Income</li><li>income confirmation from Inland Revenue</li><li>investment earning statements for the tax year </li><li>statement of earnings from your employer.</li>Additionally for self-employed people:</li><li>a copy of your complete set of financial accounts, IR3B or IR10 you provided to Inland Revenue for the income year 1 April 2016 to 31 March 2017</li><li>you cannot offset business losses against other income</li><li>business losses should be entered as $0.</li></ul>'
+      },
+      'mi': {
+        'text': 'Satisfactory proof of income includes: <ul><li>income confirmation from Work and Income</li><li>income confirmation from Inland Revenue</li><li>investment earning statements for the tax year </li><li>statement of earnings from your employer.</li>Additionally for self-employed people:</li><li>a copy of your complete set of financial accounts, IR3B or IR10 you provided to Inland Revenue for the income year 1 April 2016 to 31 March 2017</li><li>you cannot offset business losses against other income</li><li>business losses should be entered as $0.</li></ul>'
+      }
+    },
+    'component': RadioWithSelect
+  },
   {
     'component': TextBoxWithAccordian,
     'label': {

--- a/src/components/FirstTimeApplicant/WizardFormFirstPage.js
+++ b/src/components/FirstTimeApplicant/WizardFormFirstPage.js
@@ -58,7 +58,7 @@ class WizardFormFirstPage extends React.Component {
     this
       .props
       .change('what_is_your_address', state.location.location);
-      
+
     if (state['rates_bills']) {
       let attributes = state['rates_bills'][0]['attributes'];
       this.setState({
@@ -73,7 +73,8 @@ class WizardFormFirstPage extends React.Component {
 
   handleDependants(event, newValue, previousValue, name) {
     if (newValue) {
-      this.setState({dependants: newValue});
+      let dependants = (newValue >= 0 ? newValue : 0);
+      this.setState({dependants: dependants});
     }
   }
 

--- a/src/components/FirstTimeApplicant/WizardFormFirstPage.js
+++ b/src/components/FirstTimeApplicant/WizardFormFirstPage.js
@@ -82,8 +82,8 @@ class WizardFormFirstPage extends React.Component {
   }
 
   handleIncome(income, direction) {
-    // note: direction is:
-    this.setState({income: income, direction: direction});
+    // note: direction is above, between, below
+    this.setState({income, direction});
   }
 
   render() {

--- a/src/components/FirstTimeApplicant/WizardFormFirstPage.js
+++ b/src/components/FirstTimeApplicant/WizardFormFirstPage.js
@@ -78,8 +78,9 @@ class WizardFormFirstPage extends React.Component {
     }
   }
 
-  handleIncome(income, extra_income_info) {
-    this.setState({income: income, extra_income_info: extra_income_info});
+  handleIncome(income, direction) {
+    // note: direction is:
+    this.setState({income: income, direction: direction});
   }
 
   render() {
@@ -116,15 +117,19 @@ class WizardFormFirstPage extends React.Component {
                 <Address onSelection={this.handleAddressSelection} />
 
                 <Field name="valuation_id" type="hidden" component={renderField}/>
-
                 {this.state.rates_bill && this.state.rating_year && <Fragment>
                   <div className="calc-layout">
-                    My {this.state.rating_year} rates are <strong>$ {this.state.rates_bill}</strong>
+                    My {this.state.rating_year - 1} to {this.state.rating_year} rates
+                    are <strong>$ {this.state.rates_bill}</strong>
                   </div>
                 </Fragment>
                 }
+              </div>
+            </div>
 
-                {this.state.rates_bill && <Fragment>
+            {this.state.rates_bill && <Fragment>
+              <div className="arrow-box primary">
+                <div>
                   <div className="calc-layout">
                     <div>
                       I have
@@ -136,33 +141,18 @@ class WizardFormFirstPage extends React.Component {
                       dependants.
                     </div>
                   </div>
-                </Fragment>
-                }
-
-{/*                {this.state.location && <Fragment>
-                  <div className="calc-layout">
-                    <div>Who are you?</div>
-                    <Select
-                      name="what_is_your_full_name"
-                      value={this.state.selectedRatesPayer}
-                      onChange={this.handleRatesPayers}
-                      clearable={this.state.clearable}
-                      searchable={this.state.searchable}
-                      labelKey={'fullName'}
-                      valueKey={'fullName'}
-                      isLoading={this.state.isLoadingExternally}
-                      options={this.state.includedRatePayers}/>
-                  </div>
-                </Fragment>
-                }*/}
-
-                <Income
-                  dependants={this.state.dependants}
-                  rates_bill={this.state.rates_bill}
-                  onSelection={this.handleIncome}
-                />
+                </div>
               </div>
-            </div>
+            </Fragment>
+            }
+
+
+            <Income
+              dependants={this.state.dependants}
+              rates_bill={this.state.rates_bill}
+              onSelection={this.handleIncome}
+            />
+
 
             <Fragment>
               <Eligible

--- a/src/components/FirstTimeApplicant/WizardFormSecondPage.js
+++ b/src/components/FirstTimeApplicant/WizardFormSecondPage.js
@@ -63,7 +63,7 @@ class WizardFormSecondPage extends React.Component {
     };
 
     axios
-      .post(`${confisrc/components/FirstTimeApplicant/WizardFormFirstPage.jsg.API_ORIGIN}/api/v1/rebate_forms`, {data})
+      .post(`${config.API_ORIGIN}/api/v1/rebate_forms`, {data})
       .then(res => this.setState({complete: true}))
       .catch(err => this.setState({complete_error: true, complete: false}));
 

--- a/src/components/widgets/Eligible.jsx
+++ b/src/components/widgets/Eligible.jsx
@@ -1,14 +1,11 @@
 import React, {Fragment} from 'react';
-// import Select from 'react-select';
 import axios from 'axios';
 import config from '../../config';
-// import {Field, reduxForm} from 'redux-form';
 
 class Eligible extends React.Component {
   constructor(props) {
     super(props);
     this.state = {rebate: null};
-    // this.handleSelection = this.handleSelection.bind(this);
   }
 
 

--- a/src/components/widgets/Income.jsx
+++ b/src/components/widgets/Income.jsx
@@ -22,10 +22,8 @@ class Income extends React.Component {
     let income;
     if (newValue === 'below') {
       income = this.state.maximum_income_for_full_rebate;
-      this.setState({show_input: false});
     } else if (newValue === 'above') {
       income = this.state.minimum_income_for_no_rebate;
-
     }
     this.setState({income: income, show_input: (newValue == 'between')});
     this.props.onSelection(income, newValue);

--- a/src/components/widgets/Income.jsx
+++ b/src/components/widgets/Income.jsx
@@ -106,34 +106,35 @@ class Income extends React.Component {
     if (this.state.minimum_income_for_no_rebate) {
       let earnLessThan = this.getOptions();
       return (
-            <div className="arrow-box primary">
-              <div>
-        <section>
-          <label htmlFor="earn_less_than">
-            From 1st April 2016 to 31 March 2017 I earned
-          </label>
+        <div className="arrow-box primary">
+          <div>
+            <section>
+              <label htmlFor="earn_less_than">
+                From 1st April 2016 to 31 March 2017 I earned
+              </label>
 
-          <Field
-            name="income_range"
-            component={RenderRadio}
-            options={earnLessThan.options && earnLessThan.options['en']}
-            onChange={this.handleSelection}
-            className={'radio-group-income'}
-            />
-
-            {this.state.show_input &&
-            <div>
-              <label>My annual income was</label>
               <Field
-                name="income"
-                onChange={this.handleManualIncome}
-                type="text"
-                component={renderField}/>
-              <span class="reassurance">Approximate values are fine. You'll need the real values if you choose to apply</span>
-            </div>
-            }
-        </section>
-        </div></div>
+                name="income_range"
+                component={RenderRadio}
+                options={earnLessThan.options && earnLessThan.options['en']}
+                onChange={this.handleSelection}
+                className={'radio-group-income'}
+                />
+
+              {this.state.show_input &&
+                <div>
+                  <label>My annual income was</label>
+                  <Field
+                    name="income"
+                    onChange={this.handleManualIncome}
+                    type="text"
+                    component={renderField}/>
+                  <span class="reassurance">Approximate values are fine. You'll need the real values if you choose to apply</span>
+                </div>
+                }
+            </section>
+          </div>
+        </div>
       );
     }
     else {

--- a/src/components/widgets/Income.jsx
+++ b/src/components/widgets/Income.jsx
@@ -129,7 +129,9 @@ class Income extends React.Component {
                     onChange={this.handleManualIncome}
                     type="text"
                     component={renderField}/>
-                  <span class="reassurance">Approximate values are fine. You'll need the real values if you choose to apply</span>
+                  <span class="reassurance">
+                    Approximate values are fine. You'll need the real values if you choose to apply
+                  </span>
                 </div>
                 }
             </section>

--- a/src/components/widgets/Income.jsx
+++ b/src/components/widgets/Income.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import axios from 'axios';
 import config from '../../config';
 import RenderRadio from '../../components/Forms/RenderRadio';
+import renderField from '../Forms/renderField';
 import {Field} from 'redux-form';
 
 class Income extends React.Component {
@@ -9,18 +10,24 @@ class Income extends React.Component {
     super(props);
     this.state = {show_input: false};
     this.handleSelection = this.handleSelection.bind(this);
+    this.handleManualIncome = this.handleManualIncome.bind(this);
+  }
+
+  handleManualIncome(event, newValue, previousValue, name) {
+    this.setState({income: newValue});
+    this.props.onSelection(newValue, 'exact');
   }
 
   handleSelection(event, newValue, previousValue, name) {
     let income;
-    if (newValue === 'between') {
-      this.setState({show_input: true});
-    } else if (newValue === 'below') {
+    if (newValue === 'below') {
       income = this.state.maximum_income_for_full_rebate;
+      this.setState({show_input: false});
     } else if (newValue === 'above') {
       income = this.state.minimum_income_for_no_rebate;
+
     }
-    this.setState({income: income});
+    this.setState({income: income, show_input: (newValue == 'between')});
     this.props.onSelection(income, newValue);
   }
 
@@ -99,9 +106,11 @@ class Income extends React.Component {
     if (this.state.minimum_income_for_no_rebate) {
       let earnLessThan = this.getOptions();
       return (
+            <div className="arrow-box primary">
+              <div>
         <section>
           <label htmlFor="earn_less_than">
-            I earn
+            From 1st April 2016 to 31 March 2017 I earned
           </label>
 
           <Field
@@ -111,7 +120,20 @@ class Income extends React.Component {
             onChange={this.handleSelection}
             className={'radio-group-income'}
             />
+
+            {this.state.show_input &&
+            <div>
+              <label>My annual income was</label>
+              <Field
+                name="income"
+                onChange={this.handleManualIncome}
+                type="text"
+                component={renderField}/>
+              <span class="reassurance">Approximate values are fine. You'll need the real values if you choose to apply</span>
+            </div>
+            }
         </section>
+        </div></div>
       );
     }
     else {

--- a/src/components/widgets/Income.jsx
+++ b/src/components/widgets/Income.jsx
@@ -117,7 +117,7 @@ class Income extends React.Component {
                 options={earnLessThan.options && earnLessThan.options['en']}
                 onChange={this.handleSelection}
                 className={'radio-group-income'}
-                />
+              />
 
               {this.state.show_input &&
                 <div>
@@ -131,7 +131,7 @@ class Income extends React.Component {
                     Approximate values are fine. You'll need the real values if you choose to apply
                   </span>
                 </div>
-                }
+              }
             </section>
           </div>
         </div>

--- a/src/components/widgets/Income.jsx
+++ b/src/components/widgets/Income.jsx
@@ -16,9 +16,9 @@ class Income extends React.Component {
     if (newValue === 'between') {
       this.setState({show_input: true});
     } else if (newValue === 'below') {
-      income = this.state.minimum_income_for_no_rebate;
-    } else if (newValue === 'above') {
       income = this.state.maximum_income_for_full_rebate;
+    } else if (newValue === 'above') {
+      income = this.state.minimum_income_for_no_rebate;
     }
     this.setState({income: income});
     this.props.onSelection(income, newValue);

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -282,4 +282,8 @@ canvas {
 .Select {
   display: inline-block; }
 
+.reassurance {
+  font-size: 0.8em;
+  font-weight: normal; }
+
 /*# sourceMappingURL=App.css.map */

--- a/src/styles/scss/App.scss
+++ b/src/styles/scss/App.scss
@@ -399,3 +399,8 @@ canvas {
 // .Select-value {
 //   padding-top: 12px;
 // }
+
+.reassurance {
+  font-size: 0.8em;
+  font-weight: normal;
+}


### PR DESCRIPTION
# What has changed and why?

Allowed the manual entry of income

Split the address / dependants / income into their own speech bubbles.

# How to test this change
choose the "somewhere in between" option for income, then enter your income

- [ ] has automated tests
- [ ] at least one a reviewer ran the code
- [ ] tested in small screen
- [x] tested in Chrome
- [x] tested in Firefox
- [ ] tested in IE
- [ ] tested in Safari
- [ ] i18n
- [ ] tested in screen reader/contrast <-- remove this if no UX change
