### PR TITLE
Renamed form field names

### DIFF
--- a/src/JSONFormData/FirstTimeApplication.js
+++ b/src/JSONFormData/FirstTimeApplication.js
@@ -9,6 +9,7 @@ import RadioWithTextField from '../components/Forms/RadioWithTextField';
 var firstTimeApplication = [
   {
     'component': TextBoxWithAccordian,
+    'field_name': 'address',
     'label': {
       'en': {
         'text': 'What is your address?'
@@ -20,6 +21,7 @@ var firstTimeApplication = [
   },
   {
     'component': RadioWithRadio,
+    'field_name': 'date_lived_here',
     'label': {
       'en': {
         'text': 'Did you live here at 1 July 2017?'
@@ -63,6 +65,7 @@ var firstTimeApplication = [
   },
   {
     'component': TextBoxWithAccordian,
+    'field_name': 'full_name',
     'label': {
       'en': {
         'text': 'What is your full name?'
@@ -122,7 +125,8 @@ var firstTimeApplication = [
       }
     },
     'isRequired': true,
-    'component': RenderRadio
+    'component': RenderRadio,
+    'field_name': 'partner'
   },
   {
     'label': {
@@ -150,7 +154,8 @@ var firstTimeApplication = [
       }
     },
     'isRequired': true,
-    'component': RenderRadio
+    'component': RenderRadio,
+    'field_name': 'total_income'
   },
   {
     'label': {
@@ -179,6 +184,7 @@ var firstTimeApplication = [
     },
     'isRequired': true,
     'component': RadioWithTextField,
+    'field_name': 'dependants',
     'textFieldLabel': {
       'en': {
         'text': 'label'
@@ -222,6 +228,7 @@ var firstTimeApplication = [
       }
     },
     'component': RadioWithTextField,
+    'field_name': 'home_business',
     'textFieldLabel': {
       'en': {
         'text': 'Please describe how you earn money or what business you run'
@@ -276,6 +283,7 @@ var firstTimeApplication = [
   // },
   {
     'component': TextBoxWithAccordian,
+    'field_name': 'email',
     'label': {
       'en': {
         'text': 'What is your email address?'
@@ -287,6 +295,7 @@ var firstTimeApplication = [
   },
   {
     'component': TextBoxWithAccordian,
+    'field_name': 'phone_number',
     'label': {
       'en': {
         'text': 'What is your phone number?'
@@ -296,25 +305,6 @@ var firstTimeApplication = [
       }
     }
   }
-  // {
-  //   'component': TextBoxWithAccordian,
-  //   'label': {
-  //     'en': {
-  //       'text': 'What is your phone number?'
-  //     },
-  //     'mi': {
-  //       'text': 'What is your phone number?'
-  //     }
-  //   },
-  //   'instructions': {
-  //     'en': {
-  //       'text': 'This will be used so that we can send you a text confirming that your application has been received.'
-  //     },
-  //     'mi': {
-  //       'text': 'This will be used so that we can send you a text confirming that your application has been received.'
-  //     }
-  //   }
-  // }
 ];
 
 export default firstTimeApplication;

--- a/src/components/FirstTimeApplicant/WizardFormFirstPage.js
+++ b/src/components/FirstTimeApplicant/WizardFormFirstPage.js
@@ -57,8 +57,8 @@ class WizardFormFirstPage extends React.Component {
     this.setState(state);
     this
       .props
-      .change('what_is_your_address', state.location.location);
-      
+      .change('address', state.location.location);
+
     if (state['rates_bills']) {
       let attributes = state['rates_bills'][0]['attributes'];
       this.setState({
@@ -128,7 +128,7 @@ class WizardFormFirstPage extends React.Component {
                     <div>
                       I have
                       <Field
-                        name="do_you_have_dependants"
+                        name="dependants"
                         onChange={this.handleDependants}
                         type="text"
                         component={renderField}/>

--- a/src/components/FirstTimeApplicant/WizardFormSecondPage.js
+++ b/src/components/FirstTimeApplicant/WizardFormSecondPage.js
@@ -103,7 +103,7 @@ class WizardFormSecondPage extends React.Component {
                 label={label}
                 name={field.isNested
                 ? `has${camelCaser(label)}Checked`
-                : underscorize(field.label['en'].text)}
+                : field.field_name}
                 component={field.component}
                 instructions={field.instructions && field.instructions['en'].text}
                 instructionsSecondary={field.instructionsSecondary && field.instructionsSecondary['en'].text}

--- a/src/components/Forms/Radio.js
+++ b/src/components/Forms/Radio.js
@@ -32,7 +32,7 @@ class Radio extends React.Component {
   }
 
   componentDidMount() {
-    this.props.props.input.name === 'do_you_have_dependants' && this.option1.click();
+    this.props.props.input.name === 'dependants' && this.option1.click();
     this.setState({hideButtons: true});
   }
 
@@ -42,7 +42,7 @@ class Radio extends React.Component {
     return (
       <Fragment>
         <div>
-          {this.props.props.input.name === 'do_you_have_dependants' && this.state.hideButtons ? '' :
+          {this.props.props.input.name === 'dependants' && this.state.hideButtons ? '' :
             prop.options && prop.options.map((item, key) => {
               return <label key={key}>
                 <input {...prop.input} ref={i => this[`option${key+1}`] = i} type="radio" value={item} onClick={()=>{
@@ -55,12 +55,14 @@ class Radio extends React.Component {
           }
         </div>
         {this.props.fieldType === 'radio' &&
-          <FieldRadio
-            showYes={this.stateType('showYes')}
-            showNo={this.stateType('showNo')}
-            prop={prop}
-            showSub={this.stateType('sub')}
-          />
+          <Fragment>
+            <FieldRadio
+              showYes={this.stateType('showYes')}
+              showNo={this.stateType('showNo')}
+              prop={prop}
+              showSub={this.stateType('sub')}
+            />
+          </Fragment>
         }
         {this.props.fieldType === 'text' && <FieldText showYes={this.stateType('showYes')} prop={prop} submittedValue={this.props.submittedValue} /> }
       </Fragment>
@@ -96,7 +98,7 @@ const FieldSet = props => {
   return (
     <fieldset style={{marginTop: '35px'}}>
       <legend style={{marginBottom: '15px'}}>{props.prop.optionsText[1]}</legend>
-      <RadioChild name={props.prop.input.name}/>
+      <RadioChild name={`${props.prop.input.name}_child`}/>
     </fieldset>
   );
 };


### PR DESCRIPTION
updated field references on form pages
updated child radio name but affixing _child

# What has changed and why?

# How to test this change

- [ ] has automated tests
- [ ] at least one a reviewer ran the code
- [ ] tested in small screen
- [ ] tested in Chrome
- [ ] tested in Firefox
- [ ] tested in IE
- [ ] tested in Safari
- [ ] i18n
- [ ] tested in screen reader/contrast <-- remove this if no UX change
