### PR TITLE
Show the rebate amount on the signature screen

### DIFF
--- a/src/components/FirstTimeApplicant/Sign.js
+++ b/src/components/FirstTimeApplicant/Sign.js
@@ -50,7 +50,7 @@ class Sign extends React.Component {
   componentDidMount() {
     axios
       .get(`${config.API_ORIGIN}/api/v1/rebate_forms/${this.props.match.params.id}`)
-      .then(res => this.setState({fields: res.data.data.attributes.fields}))
+      .then(res => this.setState({fields: res.data.data.attributes.fields, rebate: res.data.data.attributes.rebate}))
       .catch(err => this.setState({error: true}));
   }
 
@@ -112,6 +112,10 @@ class Sign extends React.Component {
           <p>My 2017/2018 rates bill (including water) is $<strong>{this.state.fields.rates_bill}</strong>.</p>
           <p>I have {this.state.fields.dependants} dependant(s)</p>
           <p>The combined income of myself and joint-owners and partners living with me on 1 July 2017 was $<strong>{this.state.fields.income}</strong></p>
+
+          {this.state.rebate &&
+            <p>Your claimed rebate is ${this.state.rebate}</p>
+          }
 
           <h2>Sign here</h2>
 


### PR DESCRIPTION
# What has changed and why?
Feedback from Tauranga council, they asked for the rebate amount to be on the signature screen

closes #223

needs https://github.com/ServiceInnovationLab/pancake-backend/pull/89 to be live

# How to test this change

- [ ] has automated tests
- [ ] at least one a reviewer ran the code
- [ ] tested in small screen
- [ ] tested in Chrome
- [x] tested in Firefox
- [ ] tested in IE
- [ ] tested in Safari
- [ ] i18n
- [ ] tested in screen reader/contrast <-- remove this if no UX change
